### PR TITLE
Updated ssh.pm - root netconf

### DIFF
--- a/lib/Net/Netconf/Access/ssh.pm
+++ b/lib/Net/Netconf/Access/ssh.pm
@@ -51,9 +51,15 @@ sub start {
     $self->trace("Starting subsystem '$self->{'server'}'...");
     my $subsystem = $chan->subsystem($self->{'server'});
     if(!$subsystem) {
-        $self->trace("Failed to start '$self->{'server'}' subsystem, trying to exec");
-        $chan->exec($self->{'server'})
-            or croak "Failed to exec ". $self->{'server'};
+    	if ($self->{'login'} eq 'root') {
+    		$self->trace("Failed to start '$self->{'server'}' subsystem and we're logging in as root, trying to exec cli '$self->{'server'}' in exec");
+    		$chan->exec('cli ' . $self->{'server'})
+    			or croak "Failed to exec cli as root";
+    	} else {	
+        	$self->trace("Failed to start '$self->{'server'}' subsystem, trying to exec");
+        	$chan->exec($self->{'server'})
+            		or croak "Failed to exec ". $self->{'server'};
+    	}
 	$chan->flush();
 	$self->trace("Started server '$self->{'server'}' in exec");
     } else {


### PR DESCRIPTION
When we login as root, we don't launch into the CLI, so if the user is root, exec "cli netconf" so we can get a netconf session. Tested against 12.3+ and 11.4..
