### PR TITLE
adding ref to methods on object for external access

### DIFF
--- a/lib/Net/Netconf/Device.pm
+++ b/lib/Net/Netconf/Device.pm
@@ -145,6 +145,8 @@ sub new
     # Create the trace object
     $self->{'trace_obj'} = new Net::Netconf::Trace($self->{'debug_level'});
 
+    $self->{'methods'} = \%methods;
+
     # Now bring up the connection
     return $self->connect() unless $self->{'do_not_connect'};
     $self;


### PR DESCRIPTION
Adding reference to methods on object for external access. This allows us to add new commands on the object without needing to modify the module.